### PR TITLE
Properly logout user to trigger account selection on next login

### DIFF
--- a/android/src/main/java/org/rncloudfs/RNCloudFsModule.java
+++ b/android/src/main/java/org/rncloudfs/RNCloudFsModule.java
@@ -410,6 +410,7 @@ public class RNCloudFsModule extends ReactContextBaseJavaModule implements Googl
                         .requestScopes(new Scope(DriveScopes.DRIVE_FILE))
                         .build();
         GoogleSignInClient client = GoogleSignIn.getClient(this.reactContext, signInOptions);
+        mDriveServiceHelper = null;
         client.signOut()
                 .addOnSuccessListener( result -> {
                     promise.resolve(true);

--- a/android/src/main/java/org/rncloudfs/RNCloudFsModule.java
+++ b/android/src/main/java/org/rncloudfs/RNCloudFsModule.java
@@ -400,6 +400,18 @@ public class RNCloudFsModule extends ReactContextBaseJavaModule implements Googl
     }
 
     @ReactMethod
+    public void getCurrentlySignedInAccountEmail(Promise promise) {
+        Log.d(TAG, "Logging out");
+
+        GoogleSignInAccount account = GoogleSignIn.getLastSignedInAccount(this.reactContext);
+        if (account == null) {
+            promise.resolve(null);
+        } else {
+            promise.resolve(account.getEmail());
+        }
+    }
+
+    @ReactMethod
     public void logout(Promise promise) {
 
         Log.d(TAG, "Requesting sign-in");


### PR DESCRIPTION
# Decription

* Added a method to get currenlty signed in email address
* Fixed logging out that was causing the library to get into a broken state on android